### PR TITLE
Call dotenv module to load local environment variables config only du…

### DIFF
--- a/server/apiServer.js
+++ b/server/apiServer.js
@@ -11,7 +11,9 @@ import {
 import request from 'request';
 
 // config
-require('dotenv').config();
+if (process.env.NODE_ENV !== 'production') {
+  require('dotenv').config();
+}
 
 const app = express();
 


### PR DESCRIPTION
…ring non-production builds

Notes to self:

Per comments on https://github.com/motdotla/dotenv/issues/126, we're now going to conditionally load dotenv config based on node environment, specifically when NOT in production.

Following error is recorded in Heroku logs.  Most likely happening due to dotenv module attempting to load non-existent .env config file on remote app.  

```
2016-12-02T14:14:45.872113+00:00 app[web.1]: { Error: ENOENT: no such file or directory, open '.env'
2016-12-02T14:14:45.872127+00:00 app[web.1]:     at Error (native)
2016-12-02T14:14:45.872129+00:00 app[web.1]:     at Object.fs.openSync (fs.js:640:18)
2016-12-02T14:14:45.872129+00:00 app[web.1]:     at Object.fs.readFileSync (fs.js:508:33)
2016-12-02T14:14:45.872130+00:00 app[web.1]:     at Object.config (/app/node_modules/dotenv/lib/main.js:30:37)
2016-12-02T14:14:45.872131+00:00 app[web.1]:     at Object.<anonymous> (/app/dist/apiServer.js:1:480)
2016-12-02T14:14:45.872132+00:00 app[web.1]:     at r (/app/dist/apiServer.js:1:169)
2016-12-02T14:14:45.872132+00:00 app[web.1]:     at e.__esModule.default (/app/dist/apiServer.js:1:256)
2016-12-02T14:14:45.872133+00:00 app[web.1]:     at Object.<anonymous> (/app/dist/apiServer.js:1:261)
2016-12-02T14:14:45.872134+00:00 app[web.1]:     at Module._compile (module.js:570:32)
2016-12-02T14:14:45.872135+00:00 app[web.1]:     at Object.Module._extensions..js (module.js:579:10) errno: -2, code: 'ENOENT', syscall: 'open', path: '.env' }
```