### PR TITLE
Fix output path of frontend bundle file

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -7,7 +7,7 @@ module.exports = {
         './index.js',
     ],
     output: {
-        path: path.join(__dirname, 'dist'),
+        path: path.join(__dirname, '..', 'dist'),
         filename: 'bundle.js',
         publicPath: '/dist/',
     },


### PR DESCRIPTION
Frontend bundle file was being built and output into the config folder where the webpack prod config file was being executed from instead of building output to dist folder from root.

Fixed issue by modifying output path to traverse one directory up to the root folder of the app.