### PR TITLE
Infinite loading

### DIFF
--- a/src/api/edamam.js
+++ b/src/api/edamam.js
@@ -1,10 +1,14 @@
 import axios from 'axios';
 import qs from 'qs';
 
-export const search = queryString =>
+export const search = ({ from, queryString, to }) =>
   axios.get(
     `/.netlify/functions/search${qs.stringify(
-      { query: queryString },
+      {
+        from,
+        query: queryString,
+        to
+      },
       { addQueryPrefix: true }
     )}`
   );

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
 import { EdamamHit } from '../types/edamam';
+import { fetchMoreRecipes } from '../redux/actions';
 import { allRecipes } from '../redux/selectors';
 import { device } from '../enums/device';
 import { space } from '../enums/space';
@@ -12,6 +13,7 @@ import SearchResultsItem from './SearchResultsItem';
 
 type SearchResultsProps = {
   allRecipes: EdamamHit[];
+  fetchMoreRecipes: () => void;
 };
 
 const Block = styled.section`
@@ -37,7 +39,10 @@ const SearchResultsList = styled.ul`
   }
 `;
 
-const SearchResults = ({ allRecipes }: SearchResultsProps) => {
+const SearchResults: React.FC<SearchResultsProps> = ({
+  allRecipes,
+  fetchMoreRecipes
+}) => {
   const [prevYPos, setPrevYPos] = useState<number>(0);
   const lastItemRef: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
   const observer = useRef(
@@ -49,9 +54,7 @@ const SearchResults = ({ allRecipes }: SearchResultsProps) => {
           prevYPos < entry.boundingClientRect.bottom
         ) {
           setPrevYPos(entry.boundingClientRect.bottom);
-          // fetch next batch of recipes based on current number of number of recipes loaded
-          // eg: 10 recipes loaded, load recipes #11 to #20
-          alert('FETCH MORE RECIPES');
+          fetchMoreRecipes();
         }
       },
       { root: null, rootMargin: '0px', threshold: 1.0 }
@@ -86,5 +89,8 @@ const SearchResults = ({ allRecipes }: SearchResultsProps) => {
 };
 
 const mapStateToProps = createStructuredSelector({ allRecipes });
-
-export default connect(mapStateToProps)(SearchResults);
+const mapDispatchToProps = { fetchMoreRecipes };
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SearchResults);

--- a/src/components/SearchResultsItem.tsx
+++ b/src/components/SearchResultsItem.tsx
@@ -51,18 +51,20 @@ const RecipeImage = styled(LazyLoadImage)`
   width: 100%;
 `;
 
-const SearchResultsItem = ({ image, label }: EdamamRecipe) => {
-  const formattedLabel: string = titleCase(label);
-  return (
-    <Block>
-      <Header title={formattedLabel}>{formattedLabel}</Header>
-      <Frame>
-        <Canvas>
-          <RecipeImage src={image} alt={formattedLabel} />
-        </Canvas>
-      </Frame>
-    </Block>
-  );
-};
+const SearchResultsItem = React.forwardRef(
+  ({ image, label }: EdamamRecipe, ref: React.Ref<HTMLElement>) => {
+    const formattedLabel: string = titleCase(label);
+    return (
+      <Block ref={ref}>
+        <Header title={formattedLabel}>{formattedLabel}</Header>
+        <Frame>
+          <Canvas>
+            <RecipeImage src={image} alt={formattedLabel} />
+          </Canvas>
+        </Frame>
+      </Block>
+    );
+  }
+);
 
 export default SearchResultsItem;

--- a/src/lambda/search.ts
+++ b/src/lambda/search.ts
@@ -24,19 +24,24 @@ const formatHitsData = (hits: EdamamHit[]) => {
 };
 
 export async function handler(event: any) {
-  const { query } = event.queryStringParameters;
+  const { from, query, to } = event.queryStringParameters;
   try {
     const { data } = await client.get(
       `/search${qs.stringify(
         {
           app_id: process.env.REACT_APP_RECIPEEK_APP_ID,
           app_key: process.env.REACT_APP_RECIPEEK_APP_KEY,
-          q: query
+          q: query,
+          from,
+          to
         },
         { addQueryPrefix: true }
       )}`,
       { headers: { Accept: 'application/json' } }
     );
+
+    console.log('data', data);
+
     return {
       statusCode: 200,
       body: JSON.stringify(formatHitsData(data.hits))

--- a/src/lambda/search.ts
+++ b/src/lambda/search.ts
@@ -40,8 +40,6 @@ export async function handler(event: any) {
       { headers: { Accept: 'application/json' } }
     );
 
-    console.log('data', data);
-
     return {
       statusCode: 200,
       body: JSON.stringify(formatHitsData(data.hits))

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -11,3 +11,15 @@ export const searchSuccessful = fsaPayload(SEARCH_SUCCESSFUL);
 
 export const SEARCH_FAILURE = 'search failure';
 export const searchFailure = fsa(SEARCH_FAILURE);
+
+export const FETCH_MORE_RECIPES = 'fetch more recipes';
+export const fetchMoreRecipes = fsa(FETCH_MORE_RECIPES);
+
+export const FETCH_MORE_RECIPES_PENDING = 'fetch more recipes pending';
+export const fetchMoreRecipesPending = fsa(FETCH_MORE_RECIPES_PENDING);
+
+export const FETCH_MORE_RECIPES_SUCCESSFUL = 'fetch more recipes successful';
+export const fetchMoreRecipesSuccessful = fsa(FETCH_MORE_RECIPES_SUCCESSFUL);
+
+export const FETCH_MORE_RECIPES_FAILURE = 'fetch more recipes failure';
+export const fetchMoreRecipesFailure = fsa(FETCH_MORE_RECIPES_FAILURE);

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -19,7 +19,9 @@ export const FETCH_MORE_RECIPES_PENDING = 'fetch more recipes pending';
 export const fetchMoreRecipesPending = fsa(FETCH_MORE_RECIPES_PENDING);
 
 export const FETCH_MORE_RECIPES_SUCCESSFUL = 'fetch more recipes successful';
-export const fetchMoreRecipesSuccessful = fsa(FETCH_MORE_RECIPES_SUCCESSFUL);
+export const fetchMoreRecipesSuccessful = fsaPayload(
+  FETCH_MORE_RECIPES_SUCCESSFUL
+);
 
 export const FETCH_MORE_RECIPES_FAILURE = 'fetch more recipes failure';
 export const fetchMoreRecipesFailure = fsa(FETCH_MORE_RECIPES_FAILURE);

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -1,4 +1,5 @@
 import {
+  FETCH_MORE_RECIPES_SUCCESSFUL,
   SEARCH,
   SEARCH_FAILURE,
   SEARCH_PENDING,
@@ -6,6 +7,7 @@ import {
 } from './actions';
 
 const INITIAL_STATE = {
+  currentSearchQuery: '',
   search: {
     error: null,
     isPending: false
@@ -19,7 +21,10 @@ const INITIAL_STATE = {
 export default function reducer(state = INITIAL_STATE, action) {
   switch (action.type) {
     case SEARCH:
-      return { ...INITIAL_STATE };
+      return {
+        ...INITIAL_STATE,
+        currentSearchQuery: action.payload
+      };
     case SEARCH_PENDING:
       return {
         ...state,
@@ -52,6 +57,23 @@ export default function reducer(state = INITIAL_STATE, action) {
         search: {
           error: action.error,
           isPending: false
+        }
+      };
+    case FETCH_MORE_RECIPES_SUCCESSFUL:
+      return {
+        ...state,
+        recipes: {
+          byId: action.payload.reduce(
+            (output, hit) => ({
+              ...output,
+              [hit.recipe.id]: hit
+            }),
+            { ...state.recipes.byId }
+          ),
+          allIds: [
+            ...state.recipes.allIds,
+            ...action.payload.map(hit => hit.recipe.id)
+          ]
         }
       };
     default:

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -8,7 +8,9 @@ import {
 const INITIAL_STATE = {
   search: {
     error: null,
-    isPending: false,
+    isPending: false
+  },
+  recipes: {
     byId: {},
     allIds: []
   }
@@ -31,7 +33,9 @@ export default function reducer(state = INITIAL_STATE, action) {
         ...state,
         search: {
           ...state.search,
-          isPending: false,
+          isPending: false
+        },
+        recipes: {
           byId: action.payload.reduce(
             (output, hit) => ({
               ...output,
@@ -46,7 +50,6 @@ export default function reducer(state = INITIAL_STATE, action) {
       return {
         ...state,
         search: {
-          ...state.search,
           error: action.error,
           isPending: false
         }

--- a/src/redux/sagas.js
+++ b/src/redux/sagas.js
@@ -1,16 +1,22 @@
-import { all, call, put, takeEvery } from 'redux-saga/effects';
+import { all, call, put, select, takeEvery } from 'redux-saga/effects';
 
 import {
+  FETCH_MORE_RECIPES,
+  fetchMoreRecipesFailure,
+  fetchMoreRecipesPending,
+  fetchMoreRecipesSuccessful,
   SEARCH,
   searchFailure,
   searchPending,
   searchSuccessful
 } from './actions';
 import { search } from '../api/edamam';
+import { currentSearchQuery, numLoadedRecipes } from './selectors';
 
 function* searchWorker({ payload }) {
+  yield put(searchPending());
+
   try {
-    yield put(searchPending());
     const { data } = yield call(search, { queryString: payload });
     yield put(searchSuccessful(data));
   } catch (e) {
@@ -23,6 +29,25 @@ function* searchSaga() {
   yield takeEvery(SEARCH, searchWorker);
 }
 
+function* fetchMoreRecipesWorker() {
+  yield put(fetchMoreRecipesPending());
+
+  const queryString = yield select(currentSearchQuery);
+  const from = yield select(numLoadedRecipes);
+
+  try {
+    const { data } = yield call(search, { from, queryString, to: from + 10 });
+    yield put(fetchMoreRecipesSuccessful(data));
+  } catch (e) {
+    console.error(e);
+    yield put(fetchMoreRecipesFailure());
+  }
+}
+
+function* fetchMoreRecipesSaga() {
+  yield takeEvery(FETCH_MORE_RECIPES, fetchMoreRecipesWorker);
+}
+
 export default function* rootSaga() {
-  yield all([searchSaga()]);
+  yield all([searchSaga(), fetchMoreRecipesSaga()]);
 }

--- a/src/redux/sagas.js
+++ b/src/redux/sagas.js
@@ -11,7 +11,7 @@ import { search } from '../api/edamam';
 function* searchWorker({ payload }) {
   try {
     yield put(searchPending());
-    const { data } = yield call(search, payload);
+    const { data } = yield call(search, { queryString: payload });
     yield put(searchSuccessful(data));
   } catch (e) {
     console.error(e);

--- a/src/redux/selectors.js
+++ b/src/redux/selectors.js
@@ -1,8 +1,9 @@
 import { createSelector } from 'reselect';
 
 const search = state => state.search;
-const recipesById = state => search(state).byId;
-const allRecipeIds = state => search(state).allIds;
+const recipes = state => state.recipes;
+const recipesById = state => recipes(state).byId;
+const allRecipeIds = state => recipes(state).allIds;
 
 export const allRecipes = createSelector(
   allRecipeIds,

--- a/src/redux/selectors.js
+++ b/src/redux/selectors.js
@@ -5,6 +5,13 @@ const recipes = state => state.recipes;
 const recipesById = state => recipes(state).byId;
 const allRecipeIds = state => recipes(state).allIds;
 
+export const currentSearchQuery = state => state.currentSearchQuery;
+
+export const numLoadedRecipes = createSelector(
+  allRecipeIds,
+  $allRecipeIds => $allRecipeIds.length
+);
+
 export const allRecipes = createSelector(
   allRecipeIds,
   recipesById,


### PR DESCRIPTION
* Update API to support `from` and `to` query params to allow us to fetch recipe ranges from the Edamam API
* Implement an IntersectionObserver to fire a callback whenever the last recipe item is rendered

**TODO:**
- [x] Fix issue where IO fires callback on initial load of the recipes. This will need to be addressed by resizing the grid to only show a certain number of items. We'll need to handle the case where all the recipes available can be shown within the viewport (read: no overflow). This case will cause the IO to perpetually fetch more recipes.